### PR TITLE
Limit to a single identifier

### DIFF
--- a/lib/funnel_cake_index/indexer_config.rb
+++ b/lib/funnel_cake_index/indexer_config.rb
@@ -43,7 +43,7 @@ settings do
 end
 
 # DPLA MAP
-to_field "id", extract_xpath("//dcterms:identifier")
+to_field "id", extract_xpath("//dcterms:identifier"), first_only
 to_field "alternativeTitle_ssim", extract_xpath("//dcterms:alternative")
 to_field "collection_ssim", extract_xpath("//dcterms:isPartOf")
 to_field "contributor_ssim", extract_xpath("//dcterms:contributor")

--- a/spec/fixtures/record.xml
+++ b/spec/fixtures/record.xml
@@ -22,6 +22,7 @@
           <dcterms:rights>U.S. and international copyright laws protect this digital image. Commercial use or distribution of the image is not permitted without prior permission of the copyright holder. Please contact the Albright College, Special Collections for permission to use the digital image.</dcterms:rights>
           <schema:fileFormat>image/jpeg</schema:fileFormat>
           <dcterms:identifier>dplapa:ALBRIGHT_sklsemphoto_38</dcterms:identifier>
+          <dcterms:identifier>ALBRIGHT_sklsemphoto_38</dcterms:identifier>
           <edm:isShownAt>http://digitalcollections.powerlibrary.org/cdm/ref/collection/sklsemphoto/id/38</edm:isShownAt>
           <edm:preview>http://digitalcollections.powerlibrary.org/utils/getthumbnail/collection/sklsemphoto/id/38</edm:preview>
           <dcterms:isPartOf>Albright College - Schuylkill Seminary Photo Collection</dcterms:isPartOf>

--- a/spec/funnel_cake_index_spec.rb
+++ b/spec/funnel_cake_index_spec.rb
@@ -30,5 +30,9 @@ RSpec.describe FunnelCakeIndex do
     it "parses out the subjects" do
       expect(mapped_record["subject_ssim"]).to eq(["Baseball players", "Baseball", "Athletes", "Sports"])
     end
+
+    it "only returns a single record" do
+      expect(mapped_record["id"].size).to eq 1
+    end
   end
 end


### PR DESCRIPTION
No matter how many identifiers are in the source records, only send a
single id value to solr. Always take the first value as the identifier.

Closes #13 